### PR TITLE
Add support for non-string types in mapAttributes

### DIFF
--- a/src/constructId.js
+++ b/src/constructId.js
@@ -18,6 +18,10 @@ function mapAttributes(attributes) {
       return undefined;
     }
 
+    if (typeof value !== 'string') {
+      return value;
+    }
+
     return `_${ kebabCase(attribute) }-${ value
       .replace(/[|&;$%@#"<>()+,]/g, '')
       .replace(/\s/g, '-') }`;


### PR DESCRIPTION
Add support for non-string types in mapAttributes since strokeWidth is a number according to proptypes.